### PR TITLE
Update: Make sure the navigationBar and SideBar can change with the status of users

### DIFF
--- a/itp-front/src/components/HomePageBanner.vue
+++ b/itp-front/src/components/HomePageBanner.vue
@@ -36,12 +36,13 @@ margin-left: 40px;
 }
 
 .content-home h1 {
-font-size: 70px;
+font-size: 80px;
 line-height: 120px;
 font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-color: #9EDCE1;
+color: rgb(90, 196, 220);
 font-weight: bolder;
 margin-left: 20px;
+text-align: center;
 text-shadow: 
     5px 5px 0 #FCE6A9, 
     -5px 5px 0 #FCE6A9, 

--- a/itp-front/src/components/LearningSideBar.vue
+++ b/itp-front/src/components/LearningSideBar.vue
@@ -25,26 +25,33 @@
           @click="$emit('update', 2)"
           :class="{ active: active === 2 }"
           class="choose">
-          <router-link to="flashcard" data-text="FlashCard">FlashCard</router-link></li>
+          <router-link v-if= "isLoggedIn" to="flashcard" data-text="FlashCard">FlashCard</router-link>
+          <a v-else  @click="showLoginForm(false)">FlashCard</a>
+        </li>
       </div>
       <div class ="choose-section">
           <li 
           @click="$emit('update', 3)"
           :class="{ active: active === 3 }"
           class="choose">
-          <router-link to="quiz" data-text="Quiz">Quiz</router-link></li>
-      </div>
+          <router-link v-if="isLoggedIn" to="quiz" data-text="Quiz">Quiz</router-link>
+          <a v-else  @click="showLoginForm(false)">Quiz</a></li>
+        </div>
       <div class ="choose-section">
           <li 
           @click="$emit('update', 4)"
           :class="{ active: active === 4 }"
           class="choose">
-          <router-link to="/communitychallenge" data-text="Community Chanllenge">Community Challenge</router-link></li>
+          <router-link v-if="isLoggedIn" to="/communitychallenge" data-text="Community Chanllenge">Community Challenge</router-link>
+          <a v-else  @click="showLoginForm(false)">Community Challenge</a>
+        </li>
       </div>
   </ul>
 </template>
 
 <script>
+import { EventBus } from '@/eventBus';
+
 export default {
 name: "SideBar",
 props: {
@@ -56,8 +63,17 @@ props: {
 emits: ["update"],
 components: {},
 data() {
-  return {};
+  return {
+    isLoggedIn: true, // initialise to not logged
+  };
 },
+created() {
+    // this.checkLoginStatus();
+    window.addEventListener('scroll', this.handleScroll);
+  },
+  destroyed() {
+    window.removeEventListener('scroll', this.handleScroll);
+  },
 methods: {
   navigateToLearning() {
     this.$router.push({ name: "/learning" });
@@ -74,8 +90,21 @@ methods: {
     if (this.$route.path !== targetRoute.path || this.$route.query.topic !== targetRoute.query.topic) {
       this.$router.push(targetRoute);
     }
-  }
-}
+  },
+  handleScroll() {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      this.isSticky = scrollTop > 50; // Adjust as needed
+  },
+  showLoginForm(isSignUp) {
+    this.isSignUp = isSignUp;
+    EventBus.$emit('toggle-login-form', this.isSignUp);
+  },
+  checkLoginStatus() {
+      // 假设已经登录，用户名为 "Alice"
+      this.isLoggedIn = true; // 设置为已登录
+      this.username = 'Alice'; // 从后端获取的用户名
+  },
+  },
 };
 </script>
 

--- a/itp-front/src/components/NavigationBar.vue
+++ b/itp-front/src/components/NavigationBar.vue
@@ -8,7 +8,6 @@
             <i class="bx bx-menu"></i>
             <i class="bx bx-x"></i>
           </div>
-
           <div class="collapse navbar-collapse" :class="{ show: active }">
             <ul class="navbar-nav">
               <!-- Home Link -->
@@ -174,7 +173,10 @@
           <!-- 判断是否登录 -->
           <template v-if="isLoggedIn">
             <div class="user-info-container">
-              <span class="after-login-username">Hi, {{ username }}</span>
+              <span class="after-login-username">
+                Hi, {{ username }}
+                <i class="el-icon-right"  @click="checkLoginStatus"></i>
+              </span>
               <el-progress :text-inside="false" :stroke-width="15" :percentage="70" class="nav-bar-progress"></el-progress>
             </div>
           </template>
@@ -217,7 +219,7 @@ export default {
   //生命周期钩子函数created()和destroyed()的使用，它们分别定义了组件在创建和销毁时的行为
   created() {
     // 模拟从后端获取登录状态和用户名
-    // this.checkLoginStatus();
+    this.checkLoginStatus();
     window.addEventListener('scroll', this.handleScroll);
   },
   destroyed() {
@@ -234,7 +236,7 @@ export default {
     //simulate the status of user changing
     checkLoginStatus() {
       // 假设已经登录，用户名为 "Alice"
-      this.isLoggedIn = true; // 设置为已登录
+      this.isLoggedIn = !this.isLoggedIn; // 设置为已登录
       this.username = 'Alice'; // 从后端获取的用户名
     }
   },
@@ -247,14 +249,14 @@ export default {
 .user-info-container {
   display: flex;
   flex-direction: column; /* 垂直方向排列 */
-  align-items: center; /* 水平方向居中对齐 */
+  align-items: center;
+  width: 100%;
 }
 .nav-bar-progress {
   width: 100%; /* 让进度条的宽度适应容器或调整为固定值 */
   min-width: 200px; /* 可根据需要设置最大宽度 */
 
 }
-
 .after-login-username {
   margin-bottom: 5px; 
   margin-right: 30px;

--- a/itp-front/src/components/NavigationBar.vue
+++ b/itp-front/src/components/NavigationBar.vue
@@ -121,15 +121,21 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li class="nav-item">
-                    <router-link to="/myquestion" class="nav-link" exact-active-class="active">
+                    <router-link v-if="isLoggedIn" to="/myquestion" class="nav-link" exact-active-class="active">
                       My Question
                     </router-link>
+                    <a v-else  @click="showLoginForm(false)">
+                      My Question
+                    </a>
                   </li>
 
                   <li class="nav-item">
-                    <router-link to="/uploadquestion" class="nav-link" exact-active-class="active">
+                    <router-link v-if = "isLoggedIn" to="/uploadquestion" class="nav-link" exact-active-class="active">
                       Upload Question
                     </router-link>
+                    <a v-else  @click="showLoginForm(false)">
+                      Upload Question
+                    </a>
                   </li>
                 </ul>
               </li>
@@ -142,14 +148,20 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li class="nav-item">
-                    <router-link to="/badges" class="nav-link" exact-active-class="active">
+                    <router-link v-if= "isLoggedIn" to="/badges" class="nav-link" exact-active-class="active">
                       Badges
                     </router-link>
+                    <a v-else  @click="showLoginForm(false)">
+                      Badges
+                    </a>
                   </li>
                   <li class="nav-item">
-                    <router-link to="/certificate" class="nav-link" exact-active-class="active">
+                    <router-link v-if="isLoggedIn" to="/certificate" class="nav-link" exact-active-class="active">
                       Certificate
                     </router-link>
+                    <a v-else  @click="showLoginForm(false)">
+                      Certificate
+                    </a>
                   </li>
                 </ul>
               </li>
@@ -205,7 +217,7 @@ export default {
   //生命周期钩子函数created()和destroyed()的使用，它们分别定义了组件在创建和销毁时的行为
   created() {
     // 模拟从后端获取登录状态和用户名
-    this.checkLoginStatus();
+    // this.checkLoginStatus();
     window.addEventListener('scroll', this.handleScroll);
   },
   destroyed() {
@@ -219,7 +231,7 @@ export default {
     showLoginForm(isSignUp) {
       EventBus.$emit('toggle-login-form', isSignUp);
     },
-    // 模拟登录状态检查
+    //simulate the status of user changing
     checkLoginStatus() {
       // 假设已经登录，用户名为 "Alice"
       this.isLoggedIn = true; // 设置为已登录


### PR DESCRIPTION
Make sure the navigationBar can change with the status of users
When users logged in, they can jump to the questionHub and Profile by click them 
When users not logged in,  if the user click "QuestionHub" and "Profile",  the login page will be viewed

Make sure the SideBar of Learning within the different status of users
When users logged in,  they can jump to the flashcard, quiz and community by click the words
When users not logged in, if the user click "Flashcard, Quiz or community", the login page will be viewed

Add the icon, So that the user can logout when they want to finish the learning temporally